### PR TITLE
Add stock command to help and fix percent formatting

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -331,7 +331,7 @@ func (app *application) getStockQuote(query string) (string, error) {
 		changeSign = "+"
 	}
 
-	result := fmt.Sprintf("%s(%s): $%.2f %s%.2f (%s%.2f%%)\n",
+	result := fmt.Sprintf("%s(%s): $%.2f %s%.2f (%s%.2f%%%%)\n",
 		symbol, companyName, quoteResponse.C,
 		changeSign, quoteResponse.D,
 		changeSign, quoteResponse.Dp)

--- a/gravybot.mush
+++ b/gravybot.mush
@@ -32,6 +32,7 @@
 &WEATHER_NONE *gravybot=^* says "gravybot weather":@pemit me=\[[name(%#)]\(%#\)] [name(%#)] says "gravybot weather [default(%#/WEATHER_LOCATION,dino)]"
 &TRANSLATE_SHORT *gravybot=^* says "gbt *":@pemit me=\[[name(%#)]\(%#\)] [name(%#)] says "gravybot translate %1"
 &GHELP_7 *gravybot=%b%bsay Gravybot translate <source language code> <target language code> <text>
+&GHELP_8 *gravybot=%b%bsay Gravybot stock <company or ticker>
 &GHELP_9 *gravybot=%bgautoreturn on|off-[name(me)] autoreturn
 @set *gravybot=MONITOR
 @set *gravybot=VISUAL


### PR DESCRIPTION
## Summary
- Add GHELP_8 entry for gravybot stock command
- Fix double percent escape in stock quote output

## Test plan
- [ ] Verify `ghelp` shows stock command
- [ ] Verify stock quote percent displays correctly