### PR TITLE
Support lat/lon coordinates in gbw weather queries

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -236,6 +236,24 @@ func (app *application) translateText(sourceLang, targetLang, text string) (stri
 	return translatedText, nil
 }
 
+// parseLatLon detects "float:float" or "float float" and normalises to "lat,lon"
+// so weatherapi.com can resolve it as coordinates.
+func parseLatLon(s string) string {
+	for _, sep := range []string{":", " "} {
+		parts := strings.SplitN(s, sep, 2)
+		if len(parts) == 2 {
+			lat := strings.TrimSpace(parts[0])
+			lon := strings.TrimSpace(parts[1])
+			if _, err1 := strconv.ParseFloat(lat, 64); err1 == nil {
+				if _, err2 := strconv.ParseFloat(lon, 64); err2 == nil {
+					return lat + "," + lon
+				}
+			}
+		}
+	}
+	return s
+}
+
 func (app *application) sendWeatherRequest(query string) (string, error) {
 	res, err := http.Get("https://api.weatherapi.com/v1/current.json?key=" + app.config.weatherapikey + "&q=" + query + "&aqi=no")
 
@@ -1610,6 +1628,7 @@ func (app *application) checkLineForRegexps(line string) (string, error) {
 				if loc == "" {
 					continue
 				}
+				loc = parseLatLon(loc)
 				query := url.QueryEscape(loc)
 
 				response, err := app.sendWeatherRequest(query)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -538,6 +538,45 @@ func TestGenerateHoroscope_OutputIsASCII(t *testing.T) {
 	}
 }
 
+// ── parseLatLon ──────────────────────────────────────────────────────────────
+
+func TestParseLatLon(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// colon separator – various sign combinations
+		{"48.8566:2.3522", "48.8566,2.3522"},
+		{"-33.8688:151.2093", "-33.8688,151.2093"},
+		{"40.7128:-74.0060", "40.7128,-74.0060"},  // NYC: positive lat, negative lon
+		{"-54.8019:-68.3030", "-54.8019,-68.3030"}, // both negative
+		{"0:0", "0,0"},
+		// space separator
+		{"48.8566 2.3522", "48.8566,2.3522"},
+		{"-33.8688 151.2093", "-33.8688,151.2093"},
+		{"40.7128 -74.0060", "40.7128,-74.0060"},
+		// integers as coords
+		{"51 0", "51,0"},
+		{"90:-180", "90,-180"}, // boundary values
+		// extra whitespace is trimmed
+		{"  48.8566 : 2.3522 ", "48.8566,2.3522"},
+		// not lat/lon — pass through unchanged
+		{"New York", "New York"},
+		{"Paris, France", "Paris, France"},
+		{"London", "London"},
+		{"48.8566", "48.8566"},                     // single float, no separator
+		{"abc:def", "abc:def"},                     // non-numeric
+		{"48.8566:not_a_float", "48.8566:not_a_float"}, // mixed valid:invalid
+		{"not_a_float:2.3522", "not_a_float:2.3522"},   // invalid:valid
+	}
+	for _, tc := range cases {
+		got := parseLatLon(tc.in)
+		if got != tc.want {
+			t.Errorf("parseLatLon(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // ── formatUSD ─────────────────────────────────────────────────────────────────
 
 func TestFormatUSD(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `parseLatLon` helper that detects `float:float` or `float float` input and normalises it to `lat,lon` for the weatherapi.com `?q=` parameter
- Wires it into the `gbw` location loop before URL-encoding
- City-name queries (e.g. `gbw Paris`, `gbw New York`) are unaffected — the conversion only fires when both sides of the separator parse as valid floats

## Usage

```
gbw 51.6417:4.8611
gbw 51.6417 4.8611
```

Both forms resolve to the same `?q=51.6417,4.8611` API call.

## Test plan

- [ ] `TestParseLatLon` — 18 cases covering both separators, all sign combinations, boundary values, whitespace trimming, and non-coordinate pass-through
- [ ] All 46 tests pass: `go test ./cmd/`