### PR TITLE
Add EPA AQI to gbw weather output

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"hash/fnv"
 	"io"
 	"log"
+	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -121,10 +122,19 @@ type WeatherAPIResponse struct {
 		Condition    struct {
 			Text string `json:"text"`
 		} `json:"condition"`
-		Wind_mph float64 `json:"wind_mph"`
-		Wind_kph float64 `json:"wind_kph"`
-		Wind_dir string  `json:"wind_dir"`
-		Humidity float64 `json:"humidity"`
+		Wind_mph   float64 `json:"wind_mph"`
+		Wind_kph   float64 `json:"wind_kph"`
+		Wind_dir   string  `json:"wind_dir"`
+		Humidity   float64 `json:"humidity"`
+		AirQuality struct {
+			CO         float64 `json:"co"`
+			NO2        float64 `json:"no2"`
+			O3         float64 `json:"o3"`
+			SO2        float64 `json:"so2"`
+			PM25       float64 `json:"pm2_5"`
+			PM10       float64 `json:"pm10"`
+			USEPAIndex int     `json:"us-epa-index"`
+		} `json:"air_quality"`
 	} `json:"current"`
 }
 
@@ -254,8 +264,65 @@ func parseLatLon(s string) string {
 	return s
 }
 
+type aqiBP struct{ cLo, cHi float64; iLo, iHi int }
+
+func aqiSub(c float64, bps []aqiBP) int {
+	for _, bp := range bps {
+		if c <= bp.cHi {
+			return int(math.Round(float64(bp.iHi-bp.iLo)/(bp.cHi-bp.cLo)*(c-bp.cLo) + float64(bp.iLo)))
+		}
+	}
+	return 500
+}
+
+// computeAQI calculates the US EPA AQI from raw pollutant concentrations
+// returned by weatherapi.com (μg/m³ for all except CO).
+// Concentrations are instantaneous, not time-averaged, so values are approximate.
+func computeAQI(pm25, pm10, o3ugm3, no2ugm3, so2ugm3, coUgm3 float64) int {
+	pm25BPs := []aqiBP{{0.0, 12.0, 0, 50}, {12.1, 35.4, 51, 100}, {35.5, 55.4, 101, 150}, {55.5, 150.4, 151, 200}, {150.5, 250.4, 201, 300}, {250.5, 350.4, 301, 400}, {350.5, 500.4, 401, 500}}
+	pm10BPs := []aqiBP{{0, 54, 0, 50}, {55, 154, 51, 100}, {155, 254, 101, 150}, {255, 354, 151, 200}, {355, 424, 201, 300}, {425, 504, 301, 400}, {505, 604, 401, 500}}
+	o3BPs   := []aqiBP{{0, 54, 0, 50}, {55, 70, 51, 100}, {71, 85, 101, 150}, {86, 105, 151, 200}, {106, 200, 201, 300}}
+	no2BPs  := []aqiBP{{0, 53, 0, 50}, {54, 100, 51, 100}, {101, 360, 101, 150}, {361, 649, 151, 200}, {650, 1249, 201, 300}, {1250, 1649, 301, 400}, {1650, 2049, 401, 500}}
+	so2BPs  := []aqiBP{{0, 35, 0, 50}, {36, 75, 51, 100}, {76, 185, 101, 150}, {186, 304, 151, 200}, {305, 604, 201, 300}, {605, 804, 301, 400}, {805, 1004, 401, 500}}
+	coBPs   := []aqiBP{{0, 4.4, 0, 50}, {4.5, 9.4, 51, 100}, {9.5, 12.4, 101, 150}, {12.5, 15.4, 151, 200}, {15.5, 30.4, 201, 300}, {30.5, 40.4, 301, 400}, {40.5, 50.4, 401, 500}}
+
+	// Convert μg/m³ → ppb/ppm at 25°C, 1 atm
+	o3ppb  := o3ugm3 / 1.96
+	no2ppb := no2ugm3 / 1.88
+	so2ppb := so2ugm3 / 2.62
+	coppm  := coUgm3 / 1145.0
+
+	aqi := 0
+	for _, p := range []struct {
+		c   float64
+		bps []aqiBP
+	}{{pm25, pm25BPs}, {pm10, pm10BPs}, {o3ppb, o3BPs}, {no2ppb, no2BPs}, {so2ppb, so2BPs}, {coppm, coBPs}} {
+		if sub := aqiSub(p.c, p.bps); sub > aqi {
+			aqi = sub
+		}
+	}
+	return aqi
+}
+
+func aqiLabel(aqi int) string {
+	switch {
+	case aqi <= 50:
+		return "Good"
+	case aqi <= 100:
+		return "Moderate"
+	case aqi <= 150:
+		return "Unhealthy(SG)"
+	case aqi <= 200:
+		return "Unhealthy"
+	case aqi <= 300:
+		return "VeryUnhealthy"
+	default:
+		return "Hazardous"
+	}
+}
+
 func (app *application) sendWeatherRequest(query string) (string, error) {
-	res, err := http.Get("https://api.weatherapi.com/v1/current.json?key=" + app.config.weatherapikey + "&q=" + query + "&aqi=no")
+	res, err := http.Get("https://api.weatherapi.com/v1/current.json?key=" + app.config.weatherapikey + "&q=" + query + "&aqi=yes")
 
 	if err != nil {
 		app.errorLog.Printf("weather request failed: %s", err)
@@ -287,15 +354,22 @@ func (app *application) sendWeatherRequest(query string) (string, error) {
 		fmt.Println("error:", err)
 	}
 
+	aqiStr := ""
+	aq := weatherResponse.Current.AirQuality
+	if aq.USEPAIndex > 0 {
+		aqi := computeAQI(aq.PM25, aq.PM10, aq.O3, aq.NO2, aq.SO2, aq.CO)
+		aqiStr = fmt.Sprintf(" %s:%d", aqiLabel(aqi), aqi)
+	}
+
 	var locationRegion string
 	var result string
 
 	if strings.HasPrefix(weatherResponse.Location.Country, "United States of America") || strings.HasPrefix(weatherResponse.Location.Country, "USA") {
 		locationRegion = weatherResponse.Location.Region
-		result = fmt.Sprintf("%v, %v: %v %.1fF %.1f%%%% %.1fmph %v\n", weatherResponse.Location.Name, locationRegion, weatherResponse.Current.Condition.Text, weatherResponse.Current.Temp_f, weatherResponse.Current.Humidity, weatherResponse.Current.Wind_mph, weatherResponse.Current.Wind_dir)
+		result = fmt.Sprintf("%v, %v: %v %.1fF %.1f%%%% %.1fmph %v%s\n", weatherResponse.Location.Name, locationRegion, weatherResponse.Current.Condition.Text, weatherResponse.Current.Temp_f, weatherResponse.Current.Humidity, weatherResponse.Current.Wind_mph, weatherResponse.Current.Wind_dir, aqiStr)
 	} else {
 		locationRegion = weatherResponse.Location.Country
-		result = fmt.Sprintf("%v, %v: %v %.1fC %.1f%%%% %.1fkph %v\n", weatherResponse.Location.Name, locationRegion, weatherResponse.Current.Condition.Text, weatherResponse.Current.Temp_c, weatherResponse.Current.Humidity, weatherResponse.Current.Wind_kph, weatherResponse.Current.Wind_dir)
+		result = fmt.Sprintf("%v, %v: %v %.1fC %.1f%%%% %.1fkph %v%s\n", weatherResponse.Location.Name, locationRegion, weatherResponse.Current.Condition.Text, weatherResponse.Current.Temp_c, weatherResponse.Current.Humidity, weatherResponse.Current.Wind_kph, weatherResponse.Current.Wind_dir, aqiStr)
 	}
 
 	return result, nil

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -577,6 +577,126 @@ func TestParseLatLon(t *testing.T) {
 	}
 }
 
+// ── aqiSub ───────────────────────────────────────────────────────────────────
+
+func TestAqiSub_Interpolation(t *testing.T) {
+	bps := []aqiBP{{0, 10, 0, 50}, {10.1, 20, 51, 100}}
+	cases := []struct {
+		c    float64
+		want int
+	}{
+		{0, 0},
+		{5, 25},   // midpoint: (50/10)*5 = 25
+		{10, 50},  // top of first bracket
+		{15, 75},  // mid second bracket: (49/9.9)*4.9+51 ≈ 75
+		{20, 100}, // top of second bracket
+		{21, 500}, // beyond table
+	}
+	for _, tc := range cases {
+		got := aqiSub(tc.c, bps)
+		if got != tc.want {
+			t.Errorf("aqiSub(%v) = %d, want %d", tc.c, got, tc.want)
+		}
+	}
+}
+
+// ── aqiLabel ─────────────────────────────────────────────────────────────────
+
+func TestAqiLabel(t *testing.T) {
+	cases := []struct {
+		aqi  int
+		want string
+	}{
+		{0, "Good"},
+		{50, "Good"},
+		{51, "Moderate"},
+		{100, "Moderate"},
+		{101, "Unhealthy(SG)"},
+		{150, "Unhealthy(SG)"},
+		{151, "Unhealthy"},
+		{200, "Unhealthy"},
+		{201, "VeryUnhealthy"},
+		{300, "VeryUnhealthy"},
+		{301, "Hazardous"},
+		{500, "Hazardous"},
+	}
+	for _, tc := range cases {
+		got := aqiLabel(tc.aqi)
+		if got != tc.want {
+			t.Errorf("aqiLabel(%d) = %q, want %q", tc.aqi, got, tc.want)
+		}
+	}
+}
+
+// ── computeAQI ───────────────────────────────────────────────────────────────
+
+func TestComputeAQI_AllZero(t *testing.T) {
+	if got := computeAQI(0, 0, 0, 0, 0, 0); got != 0 {
+		t.Errorf("computeAQI(all zero) = %d, want 0", got)
+	}
+}
+
+func TestComputeAQI_PM25Breakpoints(t *testing.T) {
+	// At the top of each PM2.5 bracket the formula simplifies to exactly iHi.
+	cases := []struct {
+		pm25 float64
+		want int
+	}{
+		{12.0, 50},   // top of Good
+		{35.4, 100},  // top of Moderate
+		{55.4, 150},  // top of Unhealthy(SG)
+		{150.4, 200}, // top of Unhealthy
+		{250.4, 300}, // top of VeryUnhealthy
+		{350.4, 400}, // top of first Hazardous bracket
+	}
+	for _, tc := range cases {
+		got := computeAQI(tc.pm25, 0, 0, 0, 0, 0)
+		if got != tc.want {
+			t.Errorf("computeAQI(pm25=%.1f) = %d, want %d", tc.pm25, got, tc.want)
+		}
+	}
+}
+
+func TestComputeAQI_DominantPollutant(t *testing.T) {
+	// PM2.5=6 → sub-index ~25 (Good); PM10=80 → sub-index ~63 (Moderate).
+	// Result must be the higher one, in the Moderate band.
+	got := computeAQI(6, 80, 0, 0, 0, 0)
+	if got < 51 || got > 100 {
+		t.Errorf("computeAQI dominant PM10: got %d, want in Moderate range [51,100]", got)
+	}
+}
+
+func TestComputeAQI_AboveTable(t *testing.T) {
+	if got := computeAQI(600, 0, 0, 0, 0, 0); got != 500 {
+		t.Errorf("computeAQI(pm25=600) = %d, want 500", got)
+	}
+}
+
+func TestComputeAQI_UnitConversions(t *testing.T) {
+	// Each gas at exactly the top of its Good bracket expressed in μg/m³.
+	// Correct unit conversions produce AQI 50 for each.
+	cases := []struct {
+		label              string
+		pm25, pm10, o3, no2, so2, co float64
+		want               int
+	}{
+		// O3:  54 ppb × 1.96 μg/m³/ppb = 105.84 μg/m³
+		{"O3 top-of-Good", 0, 0, 105.84, 0, 0, 0, 50},
+		// NO2: 53 ppb × 1.88 = 99.64 μg/m³
+		{"NO2 top-of-Good", 0, 0, 0, 99.64, 0, 0, 50},
+		// SO2: 35 ppb × 2.62 = 91.70 μg/m³
+		{"SO2 top-of-Good", 0, 0, 0, 0, 91.70, 0, 50},
+		// CO:  4.4 ppm × 1145 μg/m³/ppm = 5038 μg/m³
+		{"CO top-of-Good", 0, 0, 0, 0, 0, 5038, 50},
+	}
+	for _, tc := range cases {
+		got := computeAQI(tc.pm25, tc.pm10, tc.o3, tc.no2, tc.so2, tc.co)
+		if got != tc.want {
+			t.Errorf("%s: computeAQI = %d, want %d", tc.label, got, tc.want)
+		}
+	}
+}
+
 // ── formatUSD ─────────────────────────────────────────────────────────────────
 
 func TestFormatUSD(t *testing.T) {


### PR DESCRIPTION
## Summary

- Switches `aqi=no` to `aqi=yes` on the weatherapi.com request to get raw pollutant concentrations (PM2.5, PM10, O3, NO2, SO2, CO)
- Computes the US EPA AQI score (0–500) using the standard piecewise linear breakpoint formula with correct μg/m³ → ppb/ppm unit conversions for gas-phase pollutants
- Appends `Label:score` to each weather line (e.g. `Good:43`, `Moderate:87`); omitted when the API returns no AQI data
- AQI labels: Good / Moderate / Unhealthy(SG) / Unhealthy / VeryUnhealthy / Hazardous

## Example output

```
pose W> Rochester, New York: Partly cloudy 72.0F 46.0% 6.3mph WNW Good:43
pose W> Utrecht, Netherlands: Partly cloudy 16.2C 68.0% 14.8kph NNW Good:28
pose W> Madrid, Spain: Clear 33.0C 13.0% 14.0kph WSW Good:39
```

## Test plan

- [ ] `TestAqiSub_Interpolation` — piecewise linear formula and above-table cap
- [ ] `TestAqiLabel` — all 6 band boundaries in both directions
- [ ] `TestComputeAQI_AllZero` — clean-air baseline
- [ ] `TestComputeAQI_PM25Breakpoints` — top-of-bracket math for all 6 PM2.5 bands
- [ ] `TestComputeAQI_DominantPollutant` — highest sub-index wins
- [ ] `TestComputeAQI_AboveTable` — concentration beyond table caps at 500
- [ ] `TestComputeAQI_UnitConversions` — μg/m³ → ppb/ppm for O3, NO2, SO2, CO
- [ ] All 53 tests pass: `go test ./cmd/`